### PR TITLE
fix typo as seen on issue #1

### DIFF
--- a/src/Rs/Client/GedcomxApplicationState.php
+++ b/src/Rs/Client/GedcomxApplicationState.php
@@ -1183,7 +1183,7 @@ abstract class GedcomxApplicationState
         // Exceptions are thrown if http_errors is set to true on the client.
         catch(\GuzzleHttp\Exception\BadResponseException $e) {
             $response = null;
-            $reason = 'Bas response.';
+            $reason = 'Bad response.';
             if($e->hasResponse()){
                 $response = $e->getResponse();
                 $reason = $response->getReasonPhrase();


### PR DESCRIPTION
Fix typo in error message in GedcomxApplicationState as described on issue #1
